### PR TITLE
Move more operations into the ONNX model

### DIFF
--- a/ichthywhat/inference.py
+++ b/ichthywhat/inference.py
@@ -28,12 +28,9 @@ class OnnxWrapper:
 
     def predict(self, img_path_or_file: Path | io.BytesIO) -> pd.Series:
         """Return a series mapping labels to sorted predictions for the image."""
-        img_arr = np.array(Image.open(img_path_or_file), dtype=np.uint8)
-        img_batch = np.expand_dims(img_arr, 0)
+        img = np.array(Image.open(img_path_or_file), dtype=np.uint8)
         return pd.Series(
-            data=self._ort_sess.run([self._output_name], {self._input_name: img_batch})[
-                0
-            ][0],
+            data=self._ort_sess.run([self._output_name], {self._input_name: img})[0],
             index=self._labels,
         ).sort_values(ascending=False)
 
@@ -46,7 +43,7 @@ class OnnxWrapper:
         """Return a mapping from k to accuracy@k for the given paths & labels."""
         # Note: this can be done more efficiently by batching images, but one image at
         # a time is good enough given that this function is only run for evaluation
-        # purposes.
+        # purposes. Also, batch support was removed from the model for simplicity.
         correct_at_k = {k: 0 for k in accuracy_top_ks}
         for image_path, label in zip(image_paths, labels, strict=True):
             predictions = self.predict(image_path)

--- a/ichthywhat/inference.py
+++ b/ichthywhat/inference.py
@@ -7,7 +7,6 @@ import io
 import json
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -24,15 +23,20 @@ class OnnxWrapper:
         self._labels = json.loads(
             self._ort_sess.get_modelmeta().custom_metadata_map["labels"]
         )
-        self._img_size = self._ort_sess.get_inputs()[0].shape[2:]
+        self._img_size = self._ort_sess.get_inputs()[0].shape[1:3]
         self._input_name = self._ort_sess.get_inputs()[0].name
         self._output_name = self._ort_sess.get_outputs()[0].name
 
     def predict(self, img_path_or_file: Path | io.BytesIO) -> pd.Series:
         """Return a series mapping labels to sorted predictions for the image."""
-        img = self._load_input_image(img_path_or_file)
+        img_arr = np.array(
+            Image.open(img_path_or_file).resize(self._img_size), dtype=np.uint8
+        )
+        img_batch = np.expand_dims(img_arr, 0)
         return pd.Series(
-            data=self._ort_sess.run([self._output_name], {self._input_name: img})[0][0],
+            data=self._ort_sess.run([self._output_name], {self._input_name: img_batch})[
+                0
+            ][0],
             index=self._labels,
         ).sort_values(ascending=False)
 
@@ -43,6 +47,9 @@ class OnnxWrapper:
         accuracy_top_ks: Sequence[int] = (1, 3, 10),
     ) -> dict[str, float]:
         """Return a mapping from k to accuracy@k for the given paths & labels."""
+        # Note: this can be done more efficiently by batching images, but one image at
+        # a time is good enough given that this function is only run for evaluation
+        # purposes.
         correct_at_k = {k: 0 for k in accuracy_top_ks}
         for image_path, label in zip(image_paths, labels, strict=True):
             predictions = self.predict(image_path)
@@ -53,22 +60,3 @@ class OnnxWrapper:
             f"top_{k}_accuracy": correct / len(image_paths)
             for k, correct in correct_at_k.items()
         }
-
-    def _load_input_image(
-        self, path_or_file: Path | io.BytesIO
-    ) -> np.ndarray[Any, np.dtype[np.float32]]:
-        # Starting from an RGB image with uint8 values, resize it to self._img_size and
-        # transform it to end up with an array of shape (1, 3, width, height) with
-        # float32 values in the [0, 1] range.
-        # TODO: the transpose step may be wrong for rectangular images (see
-        # TODO: torchvision.transforms.Resize versus PIL's resize)
-        return (
-            (
-                np.array(
-                    Image.open(path_or_file).resize(self._img_size), dtype=np.float32
-                )
-                / 255
-            )
-            .transpose(2, 0, 1)
-            .reshape((1, 3, *self._img_size))
-        )

--- a/ichthywhat/inference.py
+++ b/ichthywhat/inference.py
@@ -23,15 +23,12 @@ class OnnxWrapper:
         self._labels = json.loads(
             self._ort_sess.get_modelmeta().custom_metadata_map["labels"]
         )
-        self._img_size = self._ort_sess.get_inputs()[0].shape[1:3]
         self._input_name = self._ort_sess.get_inputs()[0].name
         self._output_name = self._ort_sess.get_outputs()[0].name
 
     def predict(self, img_path_or_file: Path | io.BytesIO) -> pd.Series:
         """Return a series mapping labels to sorted predictions for the image."""
-        img_arr = np.array(
-            Image.open(img_path_or_file).resize(self._img_size), dtype=np.uint8
-        )
+        img_arr = np.array(Image.open(img_path_or_file), dtype=np.uint8)
         img_batch = np.expand_dims(img_arr, 0)
         return pd.Series(
             data=self._ort_sess.run([self._output_name], {self._input_name: img_batch})[

--- a/ichthywhat/training.py
+++ b/ichthywhat/training.py
@@ -71,14 +71,14 @@ class _RgbUint8ImgToTensor(torch.nn.Module):
     Output shape: 1 x C x H x W
     """
 
-    def forward(self, rgb_uint8_img):
+    def forward(self, rgb_uint8_img: torch.Tensor) -> torch.Tensor:
         return (rgb_uint8_img.to(torch.float32) / 255).permute(2, 0, 1).unsqueeze(0)
 
 
 class _SqueezeBatch(torch.nn.Module):
     """Squeeze out the batch to go from shape 1 x classes to a flat array."""
 
-    def forward(self, batch):
+    def forward(self, batch: torch.Tensor) -> torch.Tensor:
         return batch.squeeze(0)
 
 
@@ -154,6 +154,8 @@ def export_learner_to_onnx(learner_path: Path, export_path: Path) -> None:
     # See https://github.com/microsoft/onnxruntime/issues/1455#issuecomment-514805365
     onnx_model.graph.output.pop()
     onnx_model.graph.output.append(
-        onnx.helper.ValueInfoProto(name=zipmap_node.output[0])
+        onnx.helper.ValueInfoProto(  # type: ignore[attr-defined]
+            name=zipmap_node.output[0]
+        )
     )
     onnx.save(onnx_model, str(export_path))

--- a/notebooks/03-app.ipynb
+++ b/notebooks/03-app.ipynb
@@ -23,7 +23,7 @@
     "import sys\n",
     "\n",
     "sys.path[0] = sys.path[0].replace(\"/notebooks\", \"\")\n",
-    "assert sys.path[0].endswith(\"ichthywhat\")\n",
+    "assert sys.path[0].endswith(\"ichthywhat\") or sys.path[0] == \"/vagrant\"\n",
     "\n",
     "# Portable path setup.\n",
     "from ichthywhat.constants import ROOT_PATH, DEFAULT_DATA_PATH, DEFAULT_MODELS_PATH\n",
@@ -2792,16 +2792,16 @@
     {
      "data": {
       "text/plain": [
-       "[(Path('/home/studio-lab-user/ichthywhat/data/qut-cropped-controlled/acanthaluteres-spilomelanurus-1.png'),\n",
-       "  'Acanthaluteres spilomelanurus'),\n",
-       " (Path('/home/studio-lab-user/ichthywhat/data/qut-cropped-controlled/acanthaluteres-vittiger-2.png'),\n",
-       "  'Acanthaluteres vittiger'),\n",
-       " (Path('/home/studio-lab-user/ichthywhat/data/qut-cropped-controlled/acanthaluteres-vittiger-9.png'),\n",
-       "  'Acanthaluteres vittiger'),\n",
-       " (Path('/home/studio-lab-user/ichthywhat/data/qut-cropped-controlled/acanthistius-cinctus-1.png'),\n",
-       "  'Acanthistius cinctus'),\n",
-       " (Path('/home/studio-lab-user/ichthywhat/data/qut-cropped-controlled/acanthistius-cinctus-3.png'),\n",
-       "  'Acanthistius cinctus')]"
+       "[(Path('/vagrant/data/qut-cropped-controlled/anampses-caeruleopunctatus-13.png'),\n",
+       "  'Anampses caeruleopunctatus'),\n",
+       " (Path('/vagrant/data/qut-cropped-controlled/thalassoma-trilobatum-4.png'),\n",
+       "  'Thalassoma trilobatum'),\n",
+       " (Path('/vagrant/data/qut-cropped-controlled/plotosus-lineatus-7.png'),\n",
+       "  'Plotosus lineatus'),\n",
+       " (Path('/vagrant/data/qut-cropped-controlled/cirrhilabrus-scottorum-14.png'),\n",
+       "  'Cirrhilabrus scottorum'),\n",
+       " (Path('/vagrant/data/qut-cropped-controlled/lutjanus-quinquelineatus-7.png'),\n",
+       "  'Lutjanus quinquelineatus')]"
       ]
      },
      "execution_count": 3,
@@ -3171,7 +3171,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "============= Diagnostic Run torch.onnx.export version 2.0.0+cu117 =============\n",
+      "============= Diagnostic Run torch.onnx.export version 2.0.1+cu117 =============\n",
       "verbose: False, log level: Level.ERROR\n",
       "======================= 0 NONE 0 NOTE 0 WARNING 0 ERROR ========================\n",
       "\n"
@@ -3194,9 +3194,9 @@
     {
      "data": {
       "text/plain": [
-       "{'top_1_accuracy': 0.12473572938689217,\n",
-       " 'top_3_accuracy': 0.19767441860465115,\n",
-       " 'top_10_accuracy': 0.28488372093023256}"
+       "{'top_1_accuracy': 0.12209302325581395,\n",
+       " 'top_3_accuracy': 0.19503171247357293,\n",
+       " 'top_10_accuracy': 0.2843551797040169}"
       ]
      },
      "execution_count": 6,
@@ -3214,9 +3214,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ichthywhat:Python",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-ichthywhat-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -3228,7 +3228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As part of #21, move these steps into the ONNX model to make it more self-contained:
* Conversion from RGB image to PyTorch-friendly tensor
* Removal of support for batches (not strictly necessary, but for now the model will only be used for classifying one image at a time)
* Mapping from class string name to probability